### PR TITLE
Allow prefix overide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-PREFIX = /usr
-BINDIR = $(PREFIX)/bin
-DOCDIR = $(PREFIX)/share/doc
-MANDIR = $(PREFIX)/share/man
+PREFIX ?= /usr
+BINDIR ?= $(PREFIX)/bin
+DOCDIR ?= $(PREFIX)/share/doc
+MANDIR ?= $(PREFIX)/share/man
 
 OPTFLAGS = $(shell getconf LFS_CFLAGS) -D_FORTIFY_SOURCE=2 -O2 -fstack-protector --param=ssp-buffer-size=4
 WARNFLAGS = -Wall -Wextra -std=gnu99 -pedantic -Wformat -Werror=format-security


### PR DESCRIPTION
This way I can do ``make PREFIX=/usr/local`` or whatever I prefer.