### PR TITLE
Fixes error connected with omitted byte while allocating memory.

### DIFF
--- a/pcapfix.c
+++ b/pcapfix.c
@@ -199,7 +199,7 @@ int main(int argc, char *argv[]) {
         pcapng++;
         break;
       case 'o':	/* output file name */
-        filename_fix = malloc(strlen(optarg));
+        filename_fix = malloc(strlen(optarg)+1);
 	strcpy(filename_fix, optarg);
         break;
       case 't':	/* data link type */


### PR DESCRIPTION
One byte should be added to cover the byte needed for the terminating null character.

I found this little mistake absolutely accidentally. Periodically I get couple strange symbols at the end of the output file name (fig. 1). I figured out that error is occurred when arg length  for output file name (absolute or relative name) is equal to 184. For more details see Figure 2 and Figure 3.

Figure 1.
![screenshot from 2017-10-30 13-04-05](https://user-images.githubusercontent.com/7964065/32168654-8d7f0d02-bd7e-11e7-998e-de1132836e0a.png)

Figure 2.
![screenshot from 2017-10-30 13-03-23](https://user-images.githubusercontent.com/7964065/32168417-a1419f86-bd7d-11e7-9f00-e0d86600f429.png)

Figure 3.
![screenshot from 2017-10-30 13-03-34](https://user-images.githubusercontent.com/7964065/32168436-b369105e-bd7d-11e7-91dc-c40e6fdf685d.png)



