### PR TITLE
Use <stdint.h> for portability

### DIFF
--- a/pcap.h
+++ b/pcap.h
@@ -20,6 +20,8 @@
 #ifndef PF_PCAP
 #define PF_PCAP
 
+#include <stdint.h>
+
 #define PCAP_MAGIC 0xa1b2c3d4			/* the magic of the pcap global header (non swapped) */
 #define PCAP_MAGIC_SWAPPED 0xd4c3b2a1		/* the magic of the pcap global header (non swapped) */
 #define PCAPNG_MAGIC 0x0a0d0d0a			/* the magic of the pcap global header (non swapped) */
@@ -28,21 +30,21 @@
 
 /* Global header (http://v2.nat32.com/pcap.htm) */
 struct global_hdr_s {
-  u_int32_t magic_number;   /* magic number */
-  u_int16_t version_major;  /* major version number */
-  u_int16_t version_minor;  /* minor version number */
+  uint32_t magic_number;   /* magic number */
+  uint16_t version_major;  /* major version number */
+  uint16_t version_minor;  /* minor version number */
   int32_t thiszone;       	/* GMT to local correction */
-  u_int32_t sigfigs;        /* accuracy of timestamps */
-  u_int32_t snaplen;        /* max length of captured packets, in octets */
-  u_int32_t network;        /* data link type */
+  uint32_t sigfigs;        /* accuracy of timestamps */
+  uint32_t snaplen;        /* max length of captured packets, in octets */
+  uint32_t network;        /* data link type */
 };
 
 /* Packet header (http://v2.nat32.com/pcap.htm) */
 struct packet_hdr_s {
-  u_int32_t ts_sec;         /* timestamp seconds */
-  u_int32_t ts_usec;        /* timestamp microseconds */
-  u_int32_t incl_len;       /* number of octets of packet saved in file */
-  u_int32_t orig_len;       /* actual length of packet */
+  uint32_t ts_sec;         /* timestamp seconds */
+  uint32_t ts_usec;        /* timestamp microseconds */
+  uint32_t incl_len;       /* number of octets of packet saved in file */
+  uint32_t orig_len;       /* actual length of packet */
 };
 
 /*

--- a/pcap_kuznet.h
+++ b/pcap_kuznet.h
@@ -28,13 +28,13 @@
 /* KUZNETZOV Packet Header
    http://tcpreplay.synfin.net/doxygen_yhsiam/tcpcapinfo_8c-source.html - is there an official documentation? */
 struct packet_hdr_kuznet_s {
-  u_int32_t ts_sec;         /* timestamp seconds */
-  u_int32_t ts_usec;        /* timestamp microseconds */
-  u_int32_t incl_len;       /* number of octets of packet saved in file */
-  u_int32_t orig_len;       /* actual length of packet */
+  uint32_t ts_sec;         /* timestamp seconds */
+  uint32_t ts_usec;        /* timestamp microseconds */
+  uint32_t incl_len;       /* number of octets of packet saved in file */
+  uint32_t orig_len;       /* actual length of packet */
   int32_t index;
-  u_int16_t protocol;
-  u_int8_t pkt_type;
+  uint16_t protocol;
+  uint8_t pkt_type;
 };
 
 /*

--- a/pcapfix.h
+++ b/pcapfix.h
@@ -36,11 +36,6 @@
   #define fseeko fseeko64
   #define ftello ftello64
 
-  /* compatibility for fixed size integer types on windows */
-  typedef uint8_t u_int8_t;
-  typedef uint16_t u_int16_t;
-  typedef uint32_t u_int32_t;
-
   /* truncate does not exist under windows */
   int truncate(const char *pathname, _off_t len);
 

--- a/pcapng.c
+++ b/pcapng.c
@@ -22,66 +22,66 @@
 
 /* Header of all pcapng blocks */
 struct block_header {
-	u_int32_t	block_type;    /* block type */
-	u_int32_t	total_length;  /* block length */
+	uint32_t	block_type;    /* block type */
+	uint32_t	total_length;  /* block length */
 };
 
 /* Header of all pcapng options */
 struct option_header {
-	u_int16_t		option_code;    /* option code - depending of block (0 - end of opts, 1 - comment are in common) */
-	u_int16_t		option_length;  /* option length - length of option in bytes (will be padded to 32bit) */
+	uint16_t		option_code;    /* option code - depending of block (0 - end of opts, 1 - comment are in common) */
+	uint16_t		option_length;  /* option length - length of option in bytes (will be padded to 32bit) */
 };
 
 /* Section Header Block (SHB) - ID 0x0A0D0D0A */
 struct section_header_block {
-	u_int32_t	byte_order_magic;   /* byte order magic - indicates swapped data */
-	u_int16_t		major_version;  /* major version of pcapng (1 atm) */
-	u_int16_t		minor_version;  /* minor version of pcapng (0 atm) */
+	uint32_t	byte_order_magic;   /* byte order magic - indicates swapped data */
+	uint16_t		major_version;  /* major version of pcapng (1 atm) */
+	uint16_t		minor_version;  /* minor version of pcapng (0 atm) */
 	int64_t	section_length;         /* length of section - can be -1 (parsing necessary) */
 };
 
 /* Interface Description Block (IDB) - ID 0x00000001 */
 struct interface_description_block {
-	u_int16_t		linktype;   /* the link layer type (was -network- in classic pcap global header) */
-	u_int16_t		reserved;   /* 2 bytes of reserved data */
-	u_int32_t	snaplen;        /* maximum number of bytes dumped from each packet (was -snaplen- in classic pcap global header */
+	uint16_t		linktype;   /* the link layer type (was -network- in classic pcap global header) */
+	uint16_t		reserved;   /* 2 bytes of reserved data */
+	uint32_t	snaplen;        /* maximum number of bytes dumped from each packet (was -snaplen- in classic pcap global header */
 };
 
 /* Packet Block (PB) - ID 0x00000002 (OBSOLETE - EPB should be used instead) */
 struct packet_block {
-	u_int16_t		interface_id;   /* the interface the packet was captured from - identified by interface description block in current section */
-	u_int16_t		drops_count;    /* packet dropped by IF and OS since prior packet */
-	u_int32_t	timestamp_high;     /* high bytes of timestamp */
-	u_int32_t	timestamp_low;      /* low bytes of timestamp */
-	u_int32_t	caplen;             /* length of packet in the capture file (was -incl_len- in classic pcap packet header) */
-	u_int32_t	len;                /* length of packet when transmitted (was -orig_len- in classic pcap packet header) */
+	uint16_t		interface_id;   /* the interface the packet was captured from - identified by interface description block in current section */
+	uint16_t		drops_count;    /* packet dropped by IF and OS since prior packet */
+	uint32_t	timestamp_high;     /* high bytes of timestamp */
+	uint32_t	timestamp_low;      /* low bytes of timestamp */
+	uint32_t	caplen;             /* length of packet in the capture file (was -incl_len- in classic pcap packet header) */
+	uint32_t	len;                /* length of packet when transmitted (was -orig_len- in classic pcap packet header) */
 };
 
 /* Simple Packet Block (SPB) - ID 0x00000003 */
 struct simple_packet_block {
-	u_int32_t	len;  /* length of packet when transmitted (was -orig_len- in classic pcap packet header) */
+	uint32_t	len;  /* length of packet when transmitted (was -orig_len- in classic pcap packet header) */
 };
 
 /* Name Resolution Block (NRB) - ID 0x00000004 */
 struct name_resolution_block {
-	u_int16_t		record_type;    /* type of record (ipv4 / ipv6) */
-	u_int16_t		record_length;  /* length of record value */
+	uint16_t		record_type;    /* type of record (ipv4 / ipv6) */
+	uint16_t		record_length;  /* length of record value */
 };
 
 /* Interface Statistics Block - ID 0x00000005 */
 struct interface_statistics_block {
-	u_int32_t	interface_id;     /* the interface the stats refer to - identified by interface description block in current section */
-	u_int32_t	timestamp_high;   /* high bytes of timestamp */
-	u_int32_t	timestamp_low;    /* low bytes of timestamp */
+	uint32_t	interface_id;     /* the interface the stats refer to - identified by interface description block in current section */
+	uint32_t	timestamp_high;   /* high bytes of timestamp */
+	uint32_t	timestamp_low;    /* low bytes of timestamp */
 };
 
 /* Enhanced Packet Block (EPB) - ID 0x00000006 */
 struct enhanced_packet_block {
-	u_int32_t	interface_id;     /* the interface the packet was captured from - identified by interface description block in current section */
-	u_int32_t	timestamp_high;   /* high bytes of timestamp */
-	u_int32_t	timestamp_low;    /* low bytes of timestamp */
-	u_int32_t	caplen;           /* length of packet in the capture file (was -incl_len- in classic pcap packet header) */
-	u_int32_t	len;              /* length of packet when transmitted (was -orig_len- in classic pcap packet header) */
+	uint32_t	interface_id;     /* the interface the packet was captured from - identified by interface description block in current section */
+	uint32_t	timestamp_high;   /* high bytes of timestamp */
+	uint32_t	timestamp_low;    /* low bytes of timestamp */
+	uint32_t	caplen;           /* length of packet in the capture file (was -incl_len- in classic pcap packet header) */
+	uint32_t	len;              /* length of packet when transmitted (was -orig_len- in classic pcap packet header) */
 };
 
 /*


### PR DESCRIPTION
This fixes a build failure on musl at the least. pcapfix was using
some non-standard types like u_int32_t: fortunately <stdint.h> has
a nice set of types with exactly the same properties, named e.g.
uint32_t, and so on.

It looks like MSVC provides <stdint.h> nowadays too.

This manifested in a build failure on musl systems like:
```
pcap.h:31:3: error: unknown type name u_int32_t
   31 |   u_int32_t magic_number;   /* magic number */
      |   ^~~~~~~~~
pcap.h:32:3: error: unknown type name u_int16_t
```

Bug: https://bugs.gentoo.org/712772