### PR TITLE
Update header network limit to 301

### DIFF
--- a/pcap.c
+++ b/pcap.c
@@ -305,7 +305,7 @@ int fix_pcap(FILE *pcap, FILE *pcap_fix) {
   }
 
   /* check for data link type (http://www.tcpdump.org/linktypes.html) */
-  if (conint(global_hdr.network) <= 251) {	/* data link types are <= 251 */
+  if (conint(global_hdr.network) <= 301) {	/* data link types are <= 301 */
     if (verbose) printf("[+] Data link type: %u\n", conint(global_hdr.network));
   } else {
     hdr_integ++;


### PR DESCRIPTION
The network type numeric limit has been updated to 301, per http://www.tcpdump.org/linktypes.html. This pull request updates the limit from 251 to the current value of 301.